### PR TITLE
Feature/user create3

### DIFF
--- a/src/main/java/com/spring/springbootapplication/form/UserForm.java
+++ b/src/main/java/com/spring/springbootapplication/form/UserForm.java
@@ -13,10 +13,7 @@ public class UserForm {
 
     @NotBlank(message = "メールアドレスは必ず入力してください")
     @Size(max = 255, message = "メールアドレスは255文字以内で入力してください")
-    @Pattern(
-        regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$",
-        message = "メールアドレスが正しい形式ではありません"
-    )
+    @Email(message = "メールアドレスが正しい形式ではありません")
     private String email;
 
     @NotBlank(message = "パスワードは必ず入力してください")

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -11,34 +11,26 @@
   <h2 class="mb-4 text-center">ユーザー登録</h2>
 
   <!-- 登録フォーム -->
-  <form th:action="@{/register}" th:object="${userForm}" method="post">
-    <!-- CSRFトークンは th:action で自動出力されます -->
-
+  <form th:action="@{/register}" th:object="${userForm}" method="post" novalidate>
     <!-- 氏名 -->
     <div class="mb-3">
       <label for="name" class="form-label">氏名</label>
-      <input type="text" id="name" th:field="*{name}" class="form-control"
-             placeholder="例）山田 太郎">
-      <div th:if="${#fields.hasErrors('name')}" class="text-danger small"
-           th:errors="*{name}">氏名エラー</div>
+      <input type="text" id="name" th:field="*{name}" class="form-control" placeholder="例）山田 太郎">
+      <div th:if="${#fields.hasErrors('name')}" class="text-danger small" th:errors="*{name}"></div>
     </div>
 
     <!-- メールアドレス -->
     <div class="mb-3">
       <label for="email" class="form-label">メールアドレス</label>
-      <input type="text" id="email" th:field="*{email}" class="form-control"
-             placeholder="example@example.com">
-      <div th:if="${#fields.hasErrors('email')}" class="text-danger small"
-           th:errors="*{email}">メールアドレスエラー</div>
+      <input type="email" id="email" th:field="*{email}" class="form-control" placeholder="example@example.com">
+      <div th:if="${#fields.hasErrors('email')}" class="text-danger small" th:errors="*{email}"></div>
     </div>
 
     <!-- パスワード -->
     <div class="mb-4">
       <label for="password" class="form-label">パスワード</label>
-      <input type="password" id="password" th:field="*{password}" class="form-control"
-             placeholder="英数字8文字以上">
-      <div th:if="${#fields.hasErrors('password')}" class="text-danger small"
-           th:errors="*{password}">パスワードエラー</div>
+      <input type="password" id="password" th:field="*{password}" class="form-control" placeholder="英数字8文字以上">
+      <div th:if="${#fields.hasErrors('password')}" class="text-danger small" th:errors="*{password}"></div>
     </div>
 
     <div class="d-grid">


### PR DESCRIPTION
## ユーザー新規登録機能の実装（バリデーション付きフォーム・DB保存・登録後TOP遷移）

### 概要
ユーザーの新規登録機能を実装しました。  
氏名、メールアドレス、パスワードを入力して登録できる画面と処理を作成しています。

### 変更内容
- ユーザー登録フォーム画面追加・修正  
- UserFormクラスにバリデーションアノテーションを追加（氏名・メール・パスワード）  
- UserControllerにGET/POSTの登録処理を実装  
- バリデーションエラー時のエラーメッセージ表示対応  
- 登録後はTOP画面へリダイレクト  
- 簡易TOPページの追加

### バリデーションルール

| 項目         | ルール                                   | エラーメッセージ                                                                 |
|--------------|----------------------------------------|------------------------------------------------------------------------------------|
| 氏名         | 必須、100文字以内                       | 「氏名は必ず入力してください」「氏名は100文字以内で入力してください」               |
| メールアドレス | 必須、メール形式、255文字以内           | 「メールアドレスは必ず入力してください」「メールアドレスが正しい形式ではありません」「メールアドレスは255文字以内で入力してください」 |
| パスワード   | 必須、8文字以上、英数字両方含む、255文字以内 | 「パスワードは必ず入力してください」「英数字8文字以上で入力してください」「パスワードは255文字以内で入力してください」   |

### 動作確認
- 入力エラー時に該当エラーメッセージが表示されることを確認  
- 正常登録後、DBにユーザー情報が保存されていることを確認  
- 登録後、TOPページへ遷移することを確認  

### 備考
仮のTOP画面を用意しています。  

よろしくお願いいたします。