### PR TITLE
Feature/profile edit

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -314,12 +314,11 @@ form button.login-button {
   top: 52px;
   left: 440px;
   width: 520px;
-  height: 256px;
   box-sizing: border-box;
-  padding: 16px;
+  padding: 16px 16px 16px 4px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  align-items: flex-start;
 }
 
 /* 自己紹介見出し（左上） */
@@ -341,7 +340,6 @@ form button.login-button {
   padding-left: 4px;
   padding-top: 4px;
   box-sizing: border-box;
-  margin-bottom: 16px;
 }
 
 /* 自己紹介テキスト */
@@ -354,9 +352,7 @@ form button.login-button {
 
 /* 編集ボタン */
 button.button_blue.edit-button {
-  position: absolute;
-  top: 203px;
-  left: -2px;
+  left: 0;               /* ← ここで左端に固定 */
   width: 242px;
   height: 53px;
   padding-top: 16px;
@@ -385,16 +381,12 @@ button.button_blue.edit-button:hover {
 
 /* 自己紹介テキストボックス */
 .intro-middle-box {
-  position: absolute;
-  top: 90px;
-  left: 0;
-  width: 520px;
-  height: 81px;
+  margin-top:90px; /* 58px（intro-box高さ） + 32px（余白） */
+  min-height: 145px; /* 初期の高さを固定 */
+  width: 100%;
+  padding-left: 0; /* 余計な内側余白はなし */
   box-sizing: border-box;
-  padding: 0 8px 0 0; 
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+  margin-bottom: 32px;
 }
 
 .intro-middle-box p {
@@ -495,7 +487,7 @@ button.button_blue.edit-button:hover {
   padding: 16px 40px;
   border-radius: 4px;
   background-color: #1B5678;
-  color: #fff;
+  color: #FFFFFF;
   border: none;
   font-family: 'Roboto', sans-serif;
   font-weight: 400;
@@ -506,6 +498,9 @@ button.button_blue.edit-button:hover {
   box-sizing: border-box;
   text-align: center;
   transition: background-color 0.3s ease;
+  display: block;        /* ブロック化して横幅や上下の配置を安定させる */
+  margin-top: 32px;      /* 自己紹介文との間に余白 */
+  position: static;   /* ← 絶対配置を解除する */
 }
 
 .edit-learning-chart-button:hover {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -381,7 +381,7 @@ button.button_blue.edit-button:hover {
 
 /* 自己紹介テキストボックス */
 .intro-middle-box {
-  margin-top:90px; /* 58px（intro-box高さ） + 32px（余白） */
+  margin-top: 74px; /* 58px（intro-box高さ） + 16px（余白） */
   min-height: 145px; /* 初期の高さを固定 */
   width: 100%;
   padding-left: 0; /* 余計な内側余白はなし */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -666,6 +666,7 @@ button.submit-button:hover {
 
 /* ファイル選択ボタン */
 .custom-file-btn {
+  white-space: nowrap;       /* ボタン内テキストは折り返さない */
   width: 202px;
   height: 32px;
   border-radius: 4px;
@@ -685,6 +686,10 @@ button.submit-button:hover {
 
 /* ファイル名表示用 */
 .file-name-text {
-  overflow: hidden; /* はみ出た部分は隠す */
-  text-overflow: ellipsis; /* はみ出たテキストは「…」で表示 */
+  max-width: 100%;         /* 親要素の幅までに制限 */
+  white-space: nowrap;     /* 横スクロールさせたい場合 */
+  overflow: hidden;        /* はみ出し部分を隠す */
+  text-overflow: ellipsis; /* はみ出たら「…」で表示 */
+  display: inline-block;   /* 幅を制御できるように */
+  vertical-align: middle;  /* 行内中央揃え */
 }

--- a/src/main/resources/templates/profile_edit.html
+++ b/src/main/resources/templates/profile_edit.html
@@ -41,10 +41,11 @@
               画像ファイルを添付する
             </button>
             <span id="file-name" class="file-name-text"
-                  th:attr="data-original-filename=${profileEditForm.imageFilename}"
-                  th:text="${profileEditForm.imageFilename} ?: ''">
-            </span>
+                  th:text="${profileEditForm.imageFilename} ?: ''"></span>
           </div>
+
+          <!-- hiddenで現在の画像ファイル名を送信 -->
+          <input type="hidden" name="imageFilename" th:value="${profileEditForm.imageFilename}" />
 
           <!-- 送信ボタン -->
           <div class="text-center pt-3">

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -49,7 +49,7 @@
           </div>
 
           <!-- 学習チャートボックス -->
-          <div class="learning-chart-box">
+          <!-- <div class="learning-chart-box">
               <div class="learning-chart-inner-box">
                   <div class="learning-chart-title-box">
                     <p>学習チャート</p>
@@ -58,7 +58,7 @@
                     編集する
                   </button>
               </div>
-          </div>
+          </div> -->
         </div>
       </div>
     </main>


### PR DESCRIPTION
## 自己紹介編集機能実装

---

### 概要
自己紹介編集機能（テキスト、画像を登録・編集）を実装しました。

---

### 実装内容

- 自己紹介のテキストおよび画像を登録・編集できる機能を実装  
- 自己紹介入力に対するバリデーションを追加  
  - 空ではない 
  - 50文字以上200文字以下
- バリデーションメッセージは入力欄の下に赤字で表示
  - 「自己紹介は50文字以上200文字以下で入力してください」
- 画像ファイルを添付した場合、ファイル名をボタン横に表示  
- 「自己紹介を確定する」ボタンでDBに保存  
- 登録後はTOP画面に遷移  

---

### 動作確認内容

- 自己紹介が空欄、50文字未満、200文字超過の場合、バリデーションが機能することを確認  
- エラーメッセージが1回のみ表示されることを確認 
- 画像ファイル添付時、ファイル名が表示されることを確認  
- 「自己紹介を確定する」ボタンでDBに正しく保存されることを確認  
- 登録完了後、TOPページへリダイレクトされることを確認  

---

### 追記

以下修正しました
- 自己紹介分を長文で入力するとTOPページで表示が崩れる
- 添付ファイル名が長文だと画像アップロードボタンの表示が崩れる
- 自己紹介文のバリデーションが発火すると添付した画像がリセットされる
