### PR TITLE
見た目の修正

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -266,7 +266,8 @@ form button.login-button {
 .profile-content {
   width: 100%;
   max-width: 960px;
-  height: 582px;
+  /* height: 582px; */
+  height: auto; /* ← 固定高さを解除 */
   margin: 0 auto;
   box-sizing: border-box;
   display: flex;
@@ -278,7 +279,8 @@ form button.login-button {
 .profile-intro {
   width: 100%;
   max-width: 960px;
-  height: 360px;
+  /* height: 360px; */
+  height: auto; /* ← 固定高さを解除 */
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -286,6 +288,8 @@ form button.login-button {
   position: relative;
   padding-left: 0;
   padding-bottom: 0;
+  height: auto; /* ← 固定高さを解除 */
+  align-items: flex-start; /* 画像と右側を上揃えに変更（必要に応じて） */
 }
 
 /* プロフィール画像 */
@@ -434,13 +438,13 @@ button.button_blue.edit-button:hover {
 
 /* 学習チャート全体ボックス */
 .learning-chart-box {
-  position: absolute;
+  position: static;
   top: 480px;
   left: 50%;
   transform: translateX(-50%);
   width: 960px;
   height: 331px;
-  box-sizing: border-box;
+  margin-top: 120px;
 }
 
 /* タイトル＋ボタンの親ボックス */
@@ -452,7 +456,7 @@ button.button_blue.edit-button:hover {
   flex-direction: column;
   justify-content: center; /* 縦中央揃え */
   align-items: center;     /* 横中央揃え */
-  gap: 40px;
+  gap: 8px;
   box-sizing: border-box;
 }
 
@@ -466,7 +470,7 @@ button.button_blue.edit-button:hover {
   gap: 16px;
   border-bottom: 2px solid rgba(0, 0, 0, 0.5);
   box-sizing: border-box;
-  padding-bottom: 4px;
+  padding-bottom: 16px;  
 }
 
 /* タイトルテキスト */
@@ -484,7 +488,7 @@ button.button_blue.edit-button:hover {
 .edit-learning-chart-button {
   width: 152px;
   height: 53px;
-  padding: 16px 40px;
+  padding: 0; /* paddingは一旦0に */ 
   border-radius: 4px;
   background-color: #1B5678;
   color: #FFFFFF;
@@ -492,7 +496,7 @@ button.button_blue.edit-button:hover {
   font-family: 'Roboto', sans-serif;
   font-weight: 400;
   font-size: 18px;
-  line-height: 100%;
+  line-height: 53px; /* ボタンの高さと同じにして縦中央 */
   letter-spacing: 0%;
   cursor: pointer;
   box-sizing: border-box;

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -1,29 +1,33 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-
 <head>
   <meta charset="UTF-8" />
   <title>TOPページ</title>
+
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous" />
+    integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+    crossorigin="anonymous" />
 
   <!-- 共通CSS -->
   <link rel="stylesheet" th:href="@{/css/style.css}" />
 
+  <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+    integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+    crossorigin="anonymous"></script>
 </head>
 
 <body>
-
   <div class="wrapper">
-    <!-- ヘッダー読み込み -->
+    <!-- ヘッダー -->
     <header th:replace="~{common/header :: header}"></header>
 
     <main class="profile-section">
       <div class="profile-content">
+        <!-- プロフィール全体 -->
         <div class="profile-intro">
+          <!-- プロフィール画像 -->
           <div class="profile-image-wrapper">
             <th:block th:if="${image != null}">
               <img th:src="@{/uploads/{filename}(filename=${image})}" alt="プロフィール画像" />
@@ -33,40 +37,42 @@
             </th:block>
           </div>
 
-          <!-- 名前ボックス -->
+          <!-- 名前 -->
           <div class="profile-name-box">
             <p th:text="${profileName}">名前</p>
           </div>
 
+          <!-- 自己紹介・編集ボタン -->
           <div class="profile-right-box">
-              <div class="intro-box">自己紹介</div>
-              <div class="intro-middle-box">
-                <p th:text="${bio}">自己紹介がここに表示されます</p>
-              </div>
-              <button class="button_blue edit-button" onclick="location.href='/profile/edit'">
-                自己紹介を編集する
-              </button>
-          </div>
+            <div class="intro-box">自己紹介</div>
 
-          <!-- 学習チャートボックス -->
-          <!-- <div class="learning-chart-box">
+            <div class="intro-middle-box">
+              <p th:text="${bio}">自己紹介がここに表示されます</p>
+            </div>
+
+            <button class="button_blue edit-button" onclick="location.href='/profile/edit'">
+              自己紹介を編集する
+            </button>
+
+            <!-- 学習チャート -->
+            <div class="learning-chart-box">
               <div class="learning-chart-inner-box">
-                  <div class="learning-chart-title-box">
-                    <p>学習チャート</p>
-                  </div>
-                  <button class="button_blue edit-learning-chart-button" onclick="location.href='/skill/edit'">
-                    編集する
-                  </button>
+                <div class="learning-chart-title-box">
+                  <p>学習チャート</p>
+                </div>
+                <button class="button_blue edit-learning-chart-button" onclick="location.href='/skill/edit'">
+                  編集する
+                </button>
               </div>
-          </div> -->
-        </div>
-      </div>
+            </div>
+
+          </div> <!-- profile-right-box -->
+        </div> <!-- profile-intro -->
+      </div> <!-- profile-content -->
     </main>
 
-    <!-- フッター読み込み -->
+    <!-- フッター -->
     <footer class="footer-custom" th:replace="common/footer :: footer"></footer>
   </div>
-
 </body>
-
 </html>


### PR DESCRIPTION
## 自己紹介編集機能実装


### 概要
自己紹介編集機能（テキスト、画像を登録・編集）を実装しました。

---

### 実装内容

- 自己紹介のテキストおよび画像を登録・編集できる機能を実装  
- 自己紹介入力に対するバリデーションを追加  
  - 空ではない 
  - 50文字以上200文字以下
- バリデーションメッセージは入力欄の下に赤字で表示
  - 「自己紹介は50文字以上200文字以下で入力してください」
- 画像ファイルを添付した場合、ファイル名をボタン横に表示  
- 「自己紹介を確定する」ボタンでDBに保存  
- 登録後はTOP画面に遷移  

---

### 動作確認内容

- 自己紹介が空欄、50文字未満、200文字超過の場合、バリデーションが機能することを確認  
- エラーメッセージが1回のみ表示されることを確認 
- 画像ファイル添付時、ファイル名が表示されることを確認  
- 「自己紹介を確定する」ボタンでDBに正しく保存されることを確認  
- 登録完了後、TOPページへリダイレクトされることを確認  

---

### 追記

以下修正しました
- 自己紹介分を長文で入力するとTOPページで表示が崩れる
- 添付ファイル名が長文だと画像アップロードボタンの表示が崩れる
- 自己紹介文のバリデーションが発火すると添付した画像がリセットされる
