### PR TITLE
修正

### DIFF
--- a/src/main/java/com/spring/springbootapplication/dto/ProfileEditForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/ProfileEditForm.java
@@ -1,8 +1,6 @@
 package com.spring.springbootapplication.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-
 import org.springframework.web.multipart.MultipartFile;
 
 public class ProfileEditForm {
@@ -10,10 +8,10 @@ public class ProfileEditForm {
     @Size(min = 50, max = 200, message = "自己紹介は50文字以上200文字以下で入力してください")
     private String bio;
 
-    // 画像ファイル（アップロード用）
+    // アップロード画像ファイル
     private MultipartFile image;
 
-    // 編集時に既存の画像ファイル名を保持するためのフィールド
+    // 画像ファイル名（画面表示用、DB登録用）
     private String imageFilename;
 
     // getter/setter

--- a/src/main/java/com/spring/springbootapplication/entity/User.java
+++ b/src/main/java/com/spring/springbootapplication/entity/User.java
@@ -4,82 +4,45 @@ import java.time.LocalDateTime;
 
 public class User {
 
-    private Integer id;          // ユーザーID（自動生成される主キー）
-    private String name;         // 名前
-    private String email;        // メールアドレス
-    private String password;     // パスワード（ハッシュ化推奨）
-    private LocalDateTime createdAt;  // 登録日時（DBのtimestamp型に対応）
-    private String bio;    // 自己紹介
-    private String image;  // 画像ファイル名
-    private String imageFilename;
+    private Integer id;
+    private String name;
+    private String email;
+    private String password;
+    private LocalDateTime createdAt;
+    private String bio;
+    private String image;          // 画像ファイル名（DBに保存する文字列）
+    private String imageFilename;  // 追加
 
-    // コンストラクタ（引数なし）
-    public User() {
-    }
+    // 画像バイナリデータをバイト配列で扱う
+    private byte[] imageData; // ※ DBにバイナリ保存する
+
+    public User() {}
 
     // getter / setter
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
 
-    public Integer getId() {
-        return id;
-    }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
 
-    public void setId(Integer id) {
-        this.id = id;
-    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
 
-    public String getName() {
-        return name;
-    }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
 
-    public String getEmail() {
-        return email;
-    }
+    public String getBio() { return bio; }
+    public void setBio(String bio) { this.bio = bio; }
 
-    public void setEmail(String email) {
-        this.email = email;
-    }
+    public String getImage() { return image; }
+    public void setImage(String image) { this.image = image; }
 
-    public String getPassword() {
-        return password;
-    }
+    public String getImageFilename() { return imageFilename; }
+    public void setImageFilename(String imageFilename) { this.imageFilename = imageFilename; }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    // ★ bio
-    public String getBio() {
-        return bio;
-    }
-    public void setBio(String bio) {
-        this.bio = bio;
-    }
-
-    // ★ image
-    public String getImage() {
-        return image;
-    }
-    public void setImage(String image) {
-        this.image = image;
-    }
-
-    public String getImageFilename() {
-        return imageFilename;
-    }
-    
-    public void setImageFilename(String imageFilename) {
-        this.imageFilename = imageFilename;
-    }
+    public byte[] getImageData() { return imageData; }
+    public void setImageData(byte[] imageData) { this.imageData = imageData; }
 }

--- a/src/main/java/com/spring/springbootapplication/service/UserService.java
+++ b/src/main/java/com/spring/springbootapplication/service/UserService.java
@@ -16,23 +16,38 @@ public class UserService {
         this.userMapper = userMapper;
     }
 
-    // ユーザー登録
+    /**
+     * セッションからログイン中ユーザーを取得
+     * @param session HttpSession
+     * @return ログインユーザーオブジェクト（無ければnull）
+     */
+    public User getCurrentUser(HttpSession session) {
+        return (User) session.getAttribute("loginUser");
+    }
+
+    /**
+     * 新規ユーザー登録
+     * トランザクション管理付き
+     */
     @Transactional
     public void registerUser(User user) {
         userMapper.insertUser(user);
     }
 
-    // メールアドレスで検索
+    /**
+     * メールアドレスでユーザー検索
+     * @param email 検索したいメールアドレス
+     * @return 該当ユーザー（なければnull）
+     */
     public User findByEmail(String email) {
         return userMapper.findByEmail(email);
     }
 
-    // ログイン中のユーザーをHttpSessionから取得
-    public User getCurrentUser(HttpSession session) {
-        return (User) session.getAttribute("loginUser");
-    }
-
-    // 自己紹介・画像の更新
+    /**
+     * 自己紹介や画像などのプロフィール更新
+     * トランザクション管理付き
+     * @param user 更新するUserオブジェクト
+     */
     @Transactional
     public void updateProfile(User user) {
         userMapper.updateUserProfile(user);

--- a/src/main/resources/templates/profile_edit.html
+++ b/src/main/resources/templates/profile_edit.html
@@ -34,18 +34,17 @@
           <!-- アバター画像 -->
           <label for="image" class="form-label mt-4 mb-1">アバター画像</label>
 
-          <!-- ファイル選択ボタンとファイル名 -->
+          <!-- ファイル選択ボタンとファイル名表示 -->
           <div class="file-upload-area d-flex align-items-center gap-3">
             <input type="file" id="image" name="image" class="visually-hidden" onchange="updateFileName(this)">
             <button type="button" class="custom-file-btn" onclick="document.getElementById('image').click();">
               画像ファイルを添付する
             </button>
-            <span id="file-name" class="file-name-text"
-                  th:text="${profileEditForm.imageFilename} ?: ''"></span>
+            <span id="file-name" class="file-name-text" th:text="${profileEditForm.imageFilename} ?: 'ファイル未選択'"></span>
           </div>
 
-          <!-- hiddenで現在の画像ファイル名を送信 -->
-          <input type="hidden" name="imageFilename" th:value="${profileEditForm.imageFilename}" />
+          <!-- hiddenで現在の画像ファイル名を保持 -->
+          <input type="hidden" name="imageFilename" id="hidden-filename" th:value="${profileEditForm.imageFilename}" />
 
           <!-- 送信ボタン -->
           <div class="text-center pt-3">
@@ -60,12 +59,19 @@
   <!-- フッター -->
   <footer th:replace="common/footer :: footer"></footer>
 
-  <!-- ファイル名更新スクリプト -->
   <script>
+    // ファイル選択時にファイル名表示とhiddenにセット
     function updateFileName(input) {
       const fileNameSpan = document.getElementById('file-name');
+      const hiddenInput = document.getElementById('hidden-filename');
       const file = input.files[0];
-      fileNameSpan.textContent = file ? file.name : '';
+      if (file) {
+        fileNameSpan.textContent = file.name;
+        hiddenInput.value = file.name;
+      } else {
+        fileNameSpan.textContent = 'ファイル未選択';
+        hiddenInput.value = '';
+      }
     }
   </script>
 </body>


### PR DESCRIPTION
## 自己紹介編集機能実装


### 概要
自己紹介編集機能（テキスト、画像を登録・編集）を実装しました。

---

### 実装内容

- 自己紹介のテキストおよび画像を登録・編集できる機能を実装  
- 自己紹介入力に対するバリデーションを追加  
  - 空ではない 
  - 50文字以上200文字以下
- バリデーションメッセージは入力欄の下に赤字で表示
  - 「自己紹介は50文字以上200文字以下で入力してください」
- 画像ファイルを添付した場合、ファイル名をボタン横に表示  
- 「自己紹介を確定する」ボタンでDBに保存  
- 登録後はTOP画面に遷移  

---

### 動作確認内容

- 自己紹介が空欄、50文字未満、200文字超過の場合、バリデーションが機能することを確認  
- エラーメッセージが1回のみ表示されることを確認 
- 画像ファイル添付時、ファイル名が表示されることを確認  
- 「自己紹介を確定する」ボタンでDBに正しく保存されることを確認  
- 登録完了後、TOPページへリダイレクトされることを確認  

---

### 追記

以下修正しました
- 自己紹介分を長文で入力するとTOPページで表示が崩れる
- 添付ファイル名が長文だと画像アップロードボタンの表示が崩れる
- 自己紹介文のバリデーションが発火すると添付した画像がリセットされる