### PR TITLE
Feature/profile edit

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
@@ -1,31 +1,31 @@
 package com.spring.springbootapplication.controller;
 
-import com.spring.springbootapplication.dto.ProfileEditForm;
 import com.spring.springbootapplication.entity.User;
+import com.spring.springbootapplication.dto.ProfileEditForm;
 import com.spring.springbootapplication.service.UserService;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
 @Controller
+@RequestMapping("/profile")
 public class ProfileEditController {
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    // 編集画面表示
-    @GetMapping("/profile/edit")
+    public ProfileEditController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/edit")
     public String showEditForm(Model model, HttpSession session) {
         User currentUser = userService.getCurrentUser(session);
         if (currentUser == null) {
@@ -40,8 +40,7 @@ public class ProfileEditController {
         return "profile_edit";
     }
 
-    // 編集内容送信処理
-    @PostMapping("/profile/edit")
+    @PostMapping("/edit")
     public String submitEdit(
             @Valid @ModelAttribute("profileEditForm") ProfileEditForm form,
             BindingResult bindingResult,
@@ -53,27 +52,34 @@ public class ProfileEditController {
             return "redirect:/login";
         }
 
-        // バリデーションエラー時、ファイル名が消えないように保持
+        MultipartFile uploadedImage = form.getImage();
+        if (uploadedImage != null && !uploadedImage.isEmpty()) {
+            session.setAttribute("tempImageData", uploadedImage.getBytes());
+            session.setAttribute("tempImageFilename", uploadedImage.getOriginalFilename());
+        }
+
         if (bindingResult.hasErrors()) {
-            if ((form.getImage() == null || form.getImage().isEmpty())
-                    && (form.getImageFilename() == null || form.getImageFilename().isEmpty())) {
+            if (session.getAttribute("tempImageFilename") != null) {
+                form.setImageFilename((String) session.getAttribute("tempImageFilename"));
+            } else {
                 form.setImageFilename(currentUser.getImageFilename());
             }
             return "profile_edit";
         }
 
-        // 自己紹介更新
         currentUser.setBio(form.getBio());
 
-        // 画像アップロード処理
-        if (form.getImage() != null && !form.getImage().isEmpty()) {
-            currentUser.setImageData(form.getImage().getBytes());
-            currentUser.setImageFilename(form.getImage().getOriginalFilename());
-            form.setImageFilename(form.getImage().getOriginalFilename());
-        } else {
-            // 画像アップロードなしなら既存画像情報を維持
-            form.setImageFilename(currentUser.getImageFilename());
+        byte[] imageData = (byte[]) session.getAttribute("tempImageData");
+        String imageFilename = (String) session.getAttribute("tempImageFilename");
+
+        if (imageData != null && imageFilename != null) {
+            currentUser.setImageData(imageData);
+            currentUser.setImageFilename(imageFilename);
+            form.setImageFilename(imageFilename);
         }
+
+        session.removeAttribute("tempImageData");
+        session.removeAttribute("tempImageFilename");
 
         userService.updateProfile(currentUser);
 

--- a/src/main/java/com/spring/springbootapplication/dto/ProfileEditForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/ProfileEditForm.java
@@ -12,7 +12,7 @@ public class ProfileEditForm {
     private MultipartFile image;
 
     // 画像ファイル名（画面表示用、DB登録用）
-    private String imageFilename;
+    private String imageFilename = ""; // null回避のため空文字で初期化しても良い
 
     // getter/setter
     public String getBio() {

--- a/src/main/resources/templates/profile_edit.html
+++ b/src/main/resources/templates/profile_edit.html
@@ -36,15 +36,14 @@
 
           <!-- ファイル選択ボタンとファイル名表示 -->
           <div class="file-upload-area d-flex align-items-center gap-3">
-            <input type="file" id="image" name="image" class="visually-hidden" onchange="updateFileName(this)">
+            <!-- Springのフォームバインドに合わせる -->
+            <input type="file" id="image" th:field="*{image}" class="visually-hidden" onchange="updateFileName(this)">
             <button type="button" class="custom-file-btn" onclick="document.getElementById('image').click();">
               画像ファイルを添付する
             </button>
-            <span id="file-name" class="file-name-text" th:text="${profileEditForm.imageFilename} ?: 'ファイル未選択'"></span>
+            <span id="file-name" class="file-name-text"
+                  th:text="${profileEditForm.imageFilename} ?: ''"></span>
           </div>
-
-          <!-- hiddenで現在の画像ファイル名を保持 -->
-          <input type="hidden" name="imageFilename" id="hidden-filename" th:value="${profileEditForm.imageFilename}" />
 
           <!-- 送信ボタン -->
           <div class="text-center pt-3">
@@ -63,14 +62,11 @@
     // ファイル選択時にファイル名表示とhiddenにセット
     function updateFileName(input) {
       const fileNameSpan = document.getElementById('file-name');
-      const hiddenInput = document.getElementById('hidden-filename');
       const file = input.files[0];
       if (file) {
         fileNameSpan.textContent = file.name;
-        hiddenInput.value = file.name;
       } else {
         fileNameSpan.textContent = 'ファイル未選択';
-        hiddenInput.value = '';
       }
     }
   </script>


### PR DESCRIPTION
## 自己紹介編集機能実装


### 概要
自己紹介編集機能（テキスト、画像を登録・編集）を実装しました。

---

### 実装内容

- 自己紹介のテキストおよび画像を登録・編集できる機能を実装  
- 自己紹介入力に対するバリデーションを追加  
  - 空ではない 
  - 50文字以上200文字以下
- バリデーションメッセージは入力欄の下に赤字で表示
  - 「自己紹介は50文字以上200文字以下で入力してください」
- 画像ファイルを添付した場合、ファイル名をボタン横に表示  
- 「自己紹介を確定する」ボタンでDBに保存  
- 登録後はTOP画面に遷移  

---

### 動作確認内容

- 自己紹介が空欄、50文字未満、200文字超過の場合、バリデーションが機能することを確認  
- エラーメッセージが1回のみ表示されることを確認 
- 画像ファイル添付時、ファイル名が表示されることを確認  
- 「自己紹介を確定する」ボタンでDBに正しく保存されることを確認  
- 登録完了後、TOPページへリダイレクトされることを確認  

---

### 追記

以下修正しました
- 自己紹介分を長文で入力するとTOPページで表示が崩れる
- 添付ファイル名が長文だと画像アップロードボタンの表示が崩れる
- 自己紹介文のバリデーションが発火すると添付した画像がリセットされる