### PR TITLE
画像サイズ修正

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -299,13 +299,18 @@ form button.login-button {
   border-radius: 50%;
   overflow: hidden;
   background-color: #C4C4C4;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   flex-shrink: 0;
 }
 
 .profile-image-wrapper img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
   object-position: center center;
   border-radius: 0; /* img自体は丸くしない */
   display: block;


### PR DESCRIPTION
## 自己紹介編集機能実装


### 概要
自己紹介編集機能（テキスト、画像を登録・編集）を実装しました。

---

### 実装内容

- 自己紹介のテキストおよび画像を登録・編集できる機能を実装  
- 自己紹介入力に対するバリデーションを追加  
  - 空ではない 
  - 50文字以上200文字以下
- バリデーションメッセージは入力欄の下に赤字で表示
  - 「自己紹介は50文字以上200文字以下で入力してください」
- 画像ファイルを添付した場合、ファイル名をボタン横に表示  
- 「自己紹介を確定する」ボタンでDBに保存  
- 登録後はTOP画面に遷移  

---

### 動作確認内容

- 自己紹介が空欄、50文字未満、200文字超過の場合、バリデーションが機能することを確認  
- エラーメッセージが1回のみ表示されることを確認 
- 画像ファイル添付時、ファイル名が表示されることを確認  
- 「自己紹介を確定する」ボタンでDBに正しく保存されることを確認  
- 登録完了後、TOPページへリダイレクトされることを確認  

---

### 追記

以下修正しました
- 自己紹介分を長文で入力するとTOPページで表示が崩れる
- 添付ファイル名が長文だと画像アップロードボタンの表示が崩れる
- 自己紹介文のバリデーションが発火すると添付した画像がリセットされる
- TOPページの画像表示を画像の比率を維持したまま縮小して表示されるように