### PR TITLE
削除するボタンの修正

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1337,7 +1337,7 @@ button.submit-button:hover {
   height: auto !important;  /* ★ここがポイント */
 }
 
-/* リストは「最大 3 行ぶん」まで。超えたらスクロール */
+/* リストは「最大 3 行分」まで。超えたらスクロール */
 .items-list{
   max-height: calc(73px * 3) !important; /* 行高 73px × 3 */
   overflow-y: auto !important;

--- a/src/main/resources/templates/skill_edit.html
+++ b/src/main/resources/templates/skill_edit.html
@@ -100,7 +100,7 @@
               <button class="btn-save" type="button">学習時間を保存する</button>
             </div>
             <div class="cell delete-cell">
-              <button class="btn btn-delete" type="button">削除する</button>
+              <button class="btn-delete" type="button">削除する</button>
             </div>
           </div><!-- /.item-row -->
         </div><!-- /.items-list -->


### PR DESCRIPTION
## 項目一覧ページ実装


### 概要
項目の一覧ページを実装しました。
当月データを既定表示し、当月を含む過去3ヶ月をプルダウンから切り替えられます。
項目が3件を超える場合は、テーブル内のみスクロールしてレイアウト崩れを防ぎます。

---

### 実装内容

- 当月のデータが一番最初に表示されるように実装  
- 月のデータは当月を含み過去3ヶ月分をプルダウンでそれぞれ選択できるように実装
- プルダウンで選択後、その選択した月のデータが表示されるように実装

---

### 動作確認内容

- トップページから「編集する」ボタン押下し遷移後、当月のデータが表示されていることを確認
- 月のデータは当月を含み過去3ヶ月分をプルダウンでそれぞれ選択できることを確認 
- プルダウンで選択後、その選択した月のデータが表示されることを確認  
- 学習時間が3つ以上の場合は、スキルテーブル内でスクロールされることを確認  

---

### 備考

- 追加、削除、編集機能は未実装（本 PR の対象外）

---

### 修正

- 削除するボタンだけクリックすると周りに青色のボーダーがでる　修正対応しました。