### PR TITLE
Feat/skill item create selected month

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/SkillItemController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillItemController.java
@@ -1,0 +1,115 @@
+package com.spring.springbootapplication.controller;
+
+import com.spring.springbootapplication.dto.LearningItemForm;
+import com.spring.springbootapplication.service.CategoryService;
+import com.spring.springbootapplication.service.SkillItemService;
+import com.spring.springbootapplication.service.UserService;
+import com.spring.springbootapplication.entity.User;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/skill")
+@RequiredArgsConstructor
+public class SkillItemController {
+
+    private final SkillItemService skillItemService;
+    private final CategoryService categoryService;
+    private final UserService userService;
+    private final HttpSession session;
+
+    @GetMapping("/new")
+    public String showNewForm(
+            @RequestParam String month,
+            @RequestParam Integer categoryId, 
+            @ModelAttribute("form") LearningItemForm form,
+            Model model
+    ) {
+        // ★ 未ログインならログインへ
+        User currentUser = userService.getCurrentUser(session);
+        if (currentUser == null) {
+            return "redirect:/login";
+        }
+
+        // 初期値をフォームに詰める
+        form.setLearningMonth(month);
+        form.setCategoryId(categoryId); 
+        model.addAttribute("selectedMonth", month);
+        model.addAttribute("isLoginPage", false);
+        model.addAttribute("categoryName", categoryService.getNameById(categoryId));
+        return "skill_new";
+    }
+
+    @PostMapping("/new")
+    public String create(
+            @Valid @ModelAttribute("form") LearningItemForm form,
+            BindingResult bindingResult,
+            RedirectAttributes ra,
+            Model model
+    ) {
+        // ★ 未ログインならログインへ
+        User currentUser = userService.getCurrentUser(session);
+        if (currentUser == null) {
+            return "redirect:/login";
+        }
+        final int userId = currentUser.getId().intValue();
+
+        // ★ 入力正規化（前後スペース除去）
+        if (form.getItem() != null) {
+            form.setItem(form.getItem().trim());
+        }
+
+        // 同月・同ユーザでの重複チェック
+        if (!bindingResult.hasErrors()
+                && skillItemService.existsSameItemInMonth(userId, form.getLearningMonth(), form.getItem())) {
+            bindingResult.rejectValue("item", "duplicate",
+                form.getItem() + "は既に登録されています");
+        }
+
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("selectedMonth", form.getLearningMonth());
+            model.addAttribute("isLoginPage", false);
+            // ★ エラーで戻すときも再セット（これを忘れると null になります）
+            model.addAttribute("categoryName", categoryService.getNameById(form.getCategoryId()));
+            return "skill_new";
+        }
+
+        // 登録（Service 側のシグネチャも int 受け取りに統一）
+        skillItemService.create(userId, form);
+
+        // 完了モーダル表示用フラッシュ
+        ra.addFlashAttribute("saved", true);
+        ra.addFlashAttribute("month", form.getLearningMonth());
+        ra.addFlashAttribute("categoryId", form.getCategoryId());
+
+        // 同じ /skill/new にリダイレクトしてモーダルを出す
+        return "redirect:/skill/new?month=" + form.getLearningMonth()
+                + "&categoryId=" + form.getCategoryId();
+    }
+
+    @GetMapping(value = "/new", params = "!month")
+    public String handleNewWithoutMonth(
+            @RequestParam(required = false) Integer categoryId
+    ) {
+        User u = userService.getCurrentUser(session);
+        if (u == null) return "redirect:/login";
+
+        String month = (String) session.getAttribute("selectedMonth");
+        if (month == null || month.isBlank()) {
+            month = java.time.YearMonth.now(java.time.ZoneId.of("Asia/Tokyo")).toString();
+        }
+
+        if (categoryId == null) {
+            var list = categoryService.findAllOrderById();
+            if (list.isEmpty()) return "redirect:/";
+            categoryId = list.get(0).getId();
+        }
+        return "redirect:/skill/new?month=" + month + "&categoryId=" + categoryId;
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/controller/SkillItemController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillItemController.java
@@ -87,6 +87,8 @@ public class SkillItemController {
         ra.addFlashAttribute("saved", true);
         ra.addFlashAttribute("month", form.getLearningMonth());
         ra.addFlashAttribute("categoryId", form.getCategoryId());
+        ra.addFlashAttribute("savedItem", form.getItem());
+        ra.addFlashAttribute("savedTime", form.getLearningTime());
 
         // 同じ /skill/new にリダイレクトしてモーダルを出す
         return "redirect:/skill/new?month=" + form.getLearningMonth()

--- a/src/main/java/com/spring/springbootapplication/dao/CategoryMapper.java
+++ b/src/main/java/com/spring/springbootapplication/dao/CategoryMapper.java
@@ -2,14 +2,34 @@ package com.spring.springbootapplication.dao;
 
 import com.spring.springbootapplication.entity.Category;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
+
 import java.util.List;
+
 @Mapper
 public interface CategoryMapper {
+
     @Select("""
-        SELECT id, category_name, created_at, updated_at
+        SELECT
+          id,
+          category_name AS categoryName,
+          created_at    AS createdAt,
+          updated_at    AS updatedAt
         FROM categories
         ORDER BY id
     """)
     List<Category> findAllOrderById();
+
+    // ★ 追加：主キーで1件取得
+    @Select("""
+        SELECT
+          id,
+          category_name AS categoryName,
+          created_at    AS createdAt,
+          updated_at    AS updatedAt
+        FROM categories
+        WHERE id = #{id}
+    """)
+    Category findById(@Param("id") int id);
 }

--- a/src/main/java/com/spring/springbootapplication/dao/LearningDataMapper.java
+++ b/src/main/java/com/spring/springbootapplication/dao/LearningDataMapper.java
@@ -1,16 +1,37 @@
 package com.spring.springbootapplication.dao;
 
 import com.spring.springbootapplication.entity.LearningData;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 
 import java.util.List;
 
 @Mapper
 public interface LearningDataMapper {
 
-    // 指定ユーザー・月のデータを取得
+    // 既存分：指定ユーザー・月のデータ取得
     @Select("SELECT * FROM learning_data WHERE user_id = #{userId} AND learning_month = #{learningMonth}")
-    List<LearningData> findByUserIdAndMonth(int userId, String learningMonth);
+    List<LearningData> findByUserIdAndMonth(@Param("userId") int userId,
+                                            @Param("learningMonth") String learningMonth);
 
+    // 追加分：同一ユーザー・同一月・同一項目名の重複チェック
+    @Select("""
+        SELECT COUNT(*)
+          FROM learning_data
+         WHERE user_id = #{userId}
+           AND learning_month = #{month}
+           AND item = #{item}
+        """)
+    int countByUserAndMonthAndItem(@Param("userId") int userId,
+                                   @Param("month") String month,
+                                   @Param("item") String item);
+
+    // 追加分：登録
+    @Insert("""
+        INSERT INTO learning_data
+          (user_id, category_id, item, learning_month, learning_time, created_at, updated_at)
+        VALUES
+          (#{userId}, #{categoryId}, #{item}, #{learningMonth}, #{learningTime}, now(), now())
+        """)
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void insert(LearningData data);
 }

--- a/src/main/java/com/spring/springbootapplication/dto/LearningItemForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/LearningItemForm.java
@@ -1,0 +1,24 @@
+package com.spring.springbootapplication.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Data;
+
+@Data
+public class LearningItemForm {
+
+    // hiddenで受け取る選択中の月
+    @NotBlank
+    private String learningMonth; // "YYYY-MM"
+
+    // hiddenで受け取るカテゴリ（一覧のどの枠から来たか）
+    @NotNull
+    private Integer categoryId;    // ← Long から Integer に変更
+
+    @NotBlank(message = "項目名は必ず入力してください")
+    @Size(max = 50, message = "項目名は50文字以内で入力してください")
+    private String item; // 項目名
+
+    @NotNull(message = "学習時間は必ず入力してください")
+    @PositiveOrZero(message = "学習時間は0以上の数字で入力してください")
+    private Integer learningTime; // 分
+}

--- a/src/main/java/com/spring/springbootapplication/service/CategoryService.java
+++ b/src/main/java/com/spring/springbootapplication/service/CategoryService.java
@@ -18,4 +18,13 @@ public class CategoryService {
     public List<Category> findAllOrderById() {
         return categoryMapper.findAllOrderById();
     }
+
+      // ★ idからカテゴリ名を取得（int/Integerどちらでも呼べる）
+    public String getNameById(int id) {
+        Category c = categoryMapper.findById(id);
+        return (c != null && c.getCategoryName() != null) ? c.getCategoryName() : "";
+    }
+    public String getNameById(Integer id) {
+        return (id == null) ? "" : getNameById(id.intValue());
+    }
 }

--- a/src/main/java/com/spring/springbootapplication/service/SkillItemService.java
+++ b/src/main/java/com/spring/springbootapplication/service/SkillItemService.java
@@ -1,0 +1,30 @@
+package com.spring.springbootapplication.service;
+
+import com.spring.springbootapplication.dao.LearningDataMapper;
+import com.spring.springbootapplication.entity.LearningData;
+import com.spring.springbootapplication.dto.LearningItemForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SkillItemService {
+
+    private final LearningDataMapper learningDataMapper;
+
+    public boolean existsSameItemInMonth(int userId, String month, String item) {
+        return learningDataMapper.countByUserAndMonthAndItem(userId, month, item) > 0;
+    }
+
+    @Transactional
+    public void create(int userId, LearningItemForm form) {
+        LearningData ld = new LearningData();
+        ld.setUserId(userId);
+        ld.setCategoryId(form.getCategoryId());
+        ld.setItem(form.getItem());
+        ld.setLearningMonth(form.getLearningMonth());
+        ld.setLearningTime(form.getLearningTime());
+        learningDataMapper.insert(ld);
+    }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1539,6 +1539,9 @@ button.submit-button:hover {
   align-items: center;
   justify-content: center;
 
+  margin-left: auto;
+  margin-right: auto;
+
   padding: 0 80px;
   border-radius: 4px;
   background: #1B5678;
@@ -1560,3 +1563,98 @@ button.submit-button:hover {
   margin-top: 4px;                   /* 下線/ヘルプの直下に少しだけ余白 */
 }
 
+/* ===== モーダル寸法とギャップ指定 ===== */
+
+/* 画面全体のオーバーレイをグラデで塗る */
+.modal-backdrop { background-color: transparent !important; }
+.modal-backdrop.show{
+  opacity: 1 !important;
+  background:
+    linear-gradient(0deg, rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
+    linear-gradient(0deg, rgba(0,0,0,0.2), rgba(0,0,0,0.2)) !important;
+}
+
+/* モーダル（640×240 / gap:40 / 角丸なし / 影） */
+.modal-success .modal-dialog{ max-width: 640px; width: 100%; }
+.modal-success .modal-content{
+  width: 100%;
+  height: 240px;
+  background: #FFFFFF;
+  box-shadow: 0px 4px 4px 0px #00000040;
+  border: none;
+  border-radius: 0;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;     /* 横中央 */
+  justify-content: center; /* 縦中央 */
+  gap: 40px;               /* ← 本文とボタンの間隔はこれだけ */
+  padding: 0 !important;   /* 余計な内側余白を無効化 */
+}
+
+/* 本文 */
+.modal-success__msg{
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;                /* ← ここで段落間隔10px */
+  font-family: "Roboto", system-ui, -apple-system, "Segoe UI", Arial, sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 18px;
+  line-height: 1;           /* ← 行間100%を強制 */
+  letter-spacing: 0;
+  text-align: center;
+  color: rgba(0,0,0,0.75);  /* #000000BF */
+}
+.modal-success__msg .msg-row{ line-height: 1; }  /* 念のため継承固定 */
+
+/* 「編集ページに戻る」ボタン */
+.modal-success__btn{
+  width: 192px;
+  height: 48px;
+  padding: 16px 40px;          /* 上下16 / 左右40 */
+  border-radius: 4px;
+  background: #1B5678;
+  border: none;
+
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;             /* ← 親の中央に寄せる */
+  margin-right: auto;            /* ← 親の中央に寄せる */
+  white-space: nowrap;         /* ボタン内で改行しない */
+  text-decoration: none;
+
+  font-family: "Roboto", system-ui, -apple-system, "Segoe UI", Arial, sans-serif;
+  font-weight: 400;            /* Regular */
+  font-style: normal;
+  font-size: 14px;
+  line-height: 1;              /* 100% */
+  letter-spacing: 0;
+  color: #FFFFFF;
+}
+.modal-success__btn:hover,
+.modal-success__btn:focus{ color:#fff; text-decoration:none; outline:none; box-shadow:none; }
+
+/* 余計な隙間/線を消す（本文/フッター） */
+.modal-success .modal-body{
+  flex: 0 0 auto !important;   /* ← 既定の 1 1 auto を無効化 */
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* フッターも伸びない＆中央寄せ、線なし */
+.modal-success .modal-footer{
+  flex: 0 0 auto !important;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 !important;
+  margin: 0 !important;
+  border-top: none !important;
+}
+
+.modal-success__msg{ margin: 0 !important; line-height: 1 !important; }
+.modal-success__btn{ margin: 0 !important; }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -976,9 +976,38 @@ button.submit-button:hover {
   line-height: 1;
   white-space: nowrap; /* 文字を折り返さない */
 
-
+  text-decoration: none;        /* 下線を消す */
   cursor: pointer;
   opacity: 1;
+
+  /* 余計な色変化を防ぐ */
+  transition: none;
+  -webkit-tap-highlight-color: transparent; /* モバイルの青ハイライト抑制 */
+}
+
+/* ホバー/フォーカス/アクティブ/訪問済みでも見た目固定 */
+.add-item-btn:hover,
+.add-item-btn:focus,
+.add-item-btn:active,
+.add-item-btn:visited {
+  background: #1B5678;
+  color: #fff;
+  text-decoration: none;
+  box-shadow: none;
+  outline: none;
+}
+
+/* キーボード操作の視認性だけ確保（色は変えない） */
+.add-item-btn:focus-visible {
+  outline: 2px solid #09415c;
+  outline-offset: 2px;
+}
+
+/* 無効にしたいとき（aにdisabledは効かない） */
+.add-item-btn.is-disabled,
+.add-item-btn[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.5;
 }
 
 /* 項目 */
@@ -1342,3 +1371,192 @@ button.submit-button:hover {
   max-height: calc(73px * 3) !important; /* 行高 73px × 3 */
   overflow-y: auto !important;
 }
+
+
+/* ========== スキル項目追加ページ ========== */
+
+/* 見出し */
+.skillnew-heading-box{
+  width: fit-content;          /* 文字幅に合わせて伸びる */
+  margin: 39px auto 0;         /* 中央寄せ */
+}
+.skillnew-heading{
+  font-family: "Roboto", system-ui, -apple-system, "Segoe UI", Arial, sans-serif;
+  font-weight: 400;
+  font-size: 36px;
+  line-height: 1.33;
+  color: rgba(0,0,0,.75);
+  margin: 0;
+  white-space: nowrap;         /* 折り返さない */
+  display: inline-block;
+}
+
+/* 入力ブロック全体（上=項目名／中=学習時間／下=ボタン） */
+.skillnew-form-box{
+  width: 480px;
+  height: 268px;
+  margin: 79px auto 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;   
+}
+
+/* ラベル＋下線付き入力を48pxに収める（12 + 3 + 33） */
+.skillnew-field{
+  width: 480px;
+  height: 48px;
+  display: grid;
+  grid-template-rows: 12px 33px auto;
+  row-gap: 3px;
+}
+.skillnew-field .form-label{
+  margin: 0 !important;
+  font-size: 12px;
+  line-height: 12px;
+  letter-spacing: .15px;
+  color: rgba(0,0,0,.54);
+}
+
+/* 入力（フォント指定のみ修正。他数値はそのまま） */
+.skillnew-field .form-control{
+  /* ▼ フォントまわり（ご指定どおり） */
+  font-family: "Roboto", system-ui, -apple-system, "Segoe UI", Arial, sans-serif;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 19px;              /* ここだけ数値変更 */
+  letter-spacing: 0.15px;
+  color: rgba(0,0,0,.87);         /* #000000DE 相当 */
+  vertical-align: middle;
+
+  /* ▼ 既存レイアウト数値は変更しない */
+  box-sizing: border-box;
+  height: 33px !important;      /* 48 - 12 - 3 */
+  padding: 0 !important;
+  margin: 0 !important;
+
+  border: none !important;      /* 全ボーダー無効化 */
+  border-bottom: 1px solid rgba(0,0,0,.42) !important;  /* 下線(0.42) */
+  border-radius: 0 !important;
+  background: transparent !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.skillnew-field + .skillnew-field{
+  margin-top: 48px;               /* ← 好みで調整可。ヘルプには影響しない */
+}
+
+/* ヘルプ文（学習時間の下） */
+.skillnew-help{
+  width: 480px;
+  margin-top: 8px;                /* 通常は余白あり */
+  font-size: 12px;
+  line-height: 1.4;
+  color: rgba(0,0,0,.54);
+}
+.skillnew-field--time + .skillnew-help{
+  margin-top: 4px;                /* 学習時間の下線にピタ寄せ */
+}
+
+/* 既定スピナーを消す */
+.skillnew-field input[type="number"]::-webkit-outer-spin-button,
+.skillnew-field input[type="number"]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.skillnew-field input[type="number"] { -moz-appearance: textfield; appearance: textfield; }
+
+/* 入力右側にカスタムスピナー分の余白を確保（24px + α） */
+.skillnew-numwrap .form-control{
+  padding-right: 28px !important;
+}
+
+/* スピナー用ラッパ：入力(33px)の上に重ねる */
+.skillnew-numwrap{
+  position: relative;
+  height: 33px;                 /* 入力と同じ高さ */
+}
+.skillnew-spin{
+  position: absolute;
+  top: 0;                       /* 入力の上端に合わせる */
+  right: 0;
+  width: 24px;                  /* ご指定の 24 */
+  height: 33px;                 /* ご指定に合わせた 33 */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;         /* 三角自体は透過／ボタンで受ける */
+}
+
+/* クリック領域（上下） */
+.spin-btn{
+  position: relative;
+  width: 24px;
+  height: 16.5px;               /* 33を上下2分割 */
+  background: transparent;
+  border: none;
+  padding: 0;
+  pointer-events: auto;         /* クリックを受ける */
+  cursor: pointer;
+}
+
+/* 三角（10×5、上: top=8px / left=7px、色 #0000008A） */
+.spin-up::before,
+.spin-down::before{
+  content:"";
+  position: absolute;
+  left: 7px;                    /* 指定どおり */
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+}
+
+/* 上向き（top 8 / 高さ5） */
+.spin-up::before{
+  top: 8px;                     /* 指定どおり */
+  border-bottom: 5px solid rgba(0,0,0,0.54); /* #0000008A */
+}
+
+/* 下向き（三角を逆向きに、間隔は既存数値のまま） */
+.spin-down::before{
+  bottom: 9px;                  /* 指定どおり */
+  border-top: 5px solid rgba(0,0,0,0.54);
+}
+
+/* ホバー時の軽いフィードバック（任意） */
+.spin-btn:hover::before{ filter: brightness(0.5); }
+
+/* 送信ボタン */
+.skillnew-actions{
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: auto;
+}
+.skillnew-submit{
+  box-sizing: border-box;
+  width: 232px;
+  height: 53px;
+
+  /* 中央寄せ（見た目のみ。不変の数値は変更しない） */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0 80px;
+  border-radius: 4px;
+  background: #1B5678;
+  color: #FFFFFF;
+  border: none;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.skillnew-submit:hover{ filter: brightness(1.05); }
+.skillnew-submit:focus{ outline: none; box-shadow: none; }
+
+/* エラー表示（共通） */
+.skillnew-error{
+  width: 480px;
+  font-size: 12px;
+  line-height: 1.3;
+  color: #dc3545;
+  margin-top: 4px;                   /* 下線/ヘルプの直下に少しだけ余白 */
+}
+

--- a/src/main/resources/templates/skill_edit.html
+++ b/src/main/resources/templates/skill_edit.html
@@ -54,11 +54,12 @@
       </form>
 
       <!-- ▼ 可変カテゴリ。必要なら .categories-grid で3列レイアウトに -->
-<section class="categories-grid">
-  <!-- categories を回し、各カテゴリのデータを list に束ねる -->
-  <section class="category-box"
-           th:each="c : ${categories}"
-           th:with="list=${byCat[c.id]}">
+      <section class="categories-grid">
+        <!-- categories を回し、各カテゴリのデータを list に束ねる -->
+        <section class="category-box"
+                 th:each="c : ${categories}"
+                 th:with="list=${byCat[c.id]}">
+
     <div class="category-content">
 
       <!-- タイトル行：DBの category_name を見出しに -->
@@ -66,7 +67,12 @@
         <div class="category-title-box">
           <span class="category-title-text" th:text="${c.categoryName}">カテゴリ</span>
         </div>
-        <button type="button" class="add-item-btn" disabled>項目を追加する</button>
+        <th:block th:with="m=${selectedMonth != null ? selectedMonth : (param.month != null ? param.month[0] : null)}">
+          <a class="add-item-btn"
+             th:href="@{/skill/new(month=${m}, categoryId=${c.id})}">
+            項目を追加する
+          </a>
+        </th:block>
       </div>
 
       <div class="items-panel">

--- a/src/main/resources/templates/skill_new.html
+++ b/src/main/resources/templates/skill_new.html
@@ -22,7 +22,7 @@
 <!-- 共通ヘッダー -->
 <div th:replace="~{common/header :: header}"></div>
 
-<main class="container">
+<main class="container px-0">
   <div class="skillnew-heading-box">
     <h1 class="skillnew-heading"
         th:text="|${categoryName} に項目を追加|">カテゴリー名 に項目を追加</h1>
@@ -66,20 +66,28 @@
   </form>
 </main>
 
-<!-- 完了モーダル -->
-<div class="modal fade" id="saveDoneModal" tabindex="-1" aria-hidden="true"
-     th:classappend="${saved} ? ' show' : ''" th:attr="style=${saved} ? 'display:block;' : 'display:none;'">
-  <div class="modal-dialog">
+<!-- 登録完了モーダル -->
+<div class="modal fade modal-success" id="saveDoneModal" tabindex="-1" aria-hidden="true"
+     data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
-      <div class="modal-header">
-        <h2 class="modal-title fs-5">登録が完了しました</h2>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+      <div class="modal-body text-center">
+        <p class="modal-success__msg">
+          <span class="msg-row">
+            <span class="msg-strong" th:text="${categoryName}">カテゴリー名</span>
+            に
+            <span class="msg-strong" th:text="${savedItem}">項目名</span>
+            を
+          </span>
+          <span class="msg-row">
+            <span class="msg-strong" th:text="${savedTime}">60</span>分で追加しました！
+          </span>
+        </p>
       </div>
-      <div class="modal-body">
-        選択月（<span th:text="${month}">YYYY-MM</span>）として保存しました。
-      </div>
-      <div class="modal-footer">
-        <a class="btn btn-primary" th:href="@{/skill/edit(month=${month})}">編集ページに戻る</a>
+      <div class="modal-footer justify-content-center">
+        <a class="modal-success__btn" th:href="@{/skill/edit(month=${month})}">
+          編集ページに戻る
+        </a>
       </div>
     </div>
   </div>
@@ -88,12 +96,7 @@
 <!-- 共通フッター -->
 <div th:replace="~{common/footer :: footer}"></div>
 
-<script th:inline="javascript">
-  document.addEventListener('DOMContentLoaded', function () {
-    /*[[${saved}]]*/ false && new bootstrap.Modal(document.getElementById('saveDoneModal')).show();
-  });
-</script>
-<script>
+  <script>
   document.addEventListener('click', function(e){
     if(!e.target.classList.contains('spin-btn')) return;
     const wrap = e.target.closest('.skillnew-numwrap');
@@ -114,6 +117,19 @@
     // 入力イベントを発火（バリデーション反映など）
     input.dispatchEvent(new Event('input', { bubbles: true }));
   });
+  </script>
+
+  <script th:inline="javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+      const saved = /*[[${saved}]]*/ false;   // ← saved が true のときだけ実行
+      if (saved) {
+        const m = new bootstrap.Modal(document.getElementById('saveDoneModal'), {
+          backdrop: true,   // data属性と合わせておけばOK
+          keyboard: false
+        });
+        m.show();
+      }
+    });
   </script>
 </body>
 </html>

--- a/src/main/resources/templates/skill_new.html
+++ b/src/main/resources/templates/skill_new.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>項目を追加</title>
+
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+        crossorigin="anonymous" />
+
+  <!-- 共通CSS -->
+  <link rel="stylesheet" th:href="@{/css/style.css}" />
+
+  <!-- Bootstrap JS -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+          integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+          crossorigin="anonymous"></script>
+</head>
+<body>
+
+<!-- 共通ヘッダー -->
+<div th:replace="~{common/header :: header}"></div>
+
+<main class="container">
+  <div class="skillnew-heading-box">
+    <h1 class="skillnew-heading"
+        th:text="|${categoryName} に項目を追加|">カテゴリー名 に項目を追加</h1>
+  </div>
+
+  <form th:action="@{/skill/new}" th:object="${form}" method="post" novalidate>
+    <input type="hidden" th:field="*{learningMonth}">
+    <input type="hidden" th:field="*{categoryId}">
+  
+    <div class="skillnew-form-box">
+      <div class="skillnew-field">
+        <label class="form-label" th:for="*{item}">項目名</label>
+        <input type="text" th:field="*{item}" class="form-control">
+        <div class="skillnew-error"
+             th:if="${#fields.hasErrors('item')}"
+             th:errors="*{item}"></div>
+      </div>
+  
+      <div class="skillnew-field skillnew-field--time">
+        <label class="form-label" th:for="*{learningTime}">学習時間</label>
+
+        <!-- ▼ ラッパで右側にカスタムスピナーを重ねる -->
+        <div class="skillnew-numwrap">
+          <input type="number" class="form-control"
+                th:field="*{learningTime}" min="0" step="1" autocomplete="off">
+          <div class="skillnew-spin" aria-hidden="true">
+            <button type="button" class="spin-btn spin-up"  aria-label="増やす"></button>
+            <button type="button" class="spin-btn spin-down" aria-label="減らす"></button>
+          </div>
+        </div>
+      </div>
+      <div class="skillnew-help">分単位で入力してください</div>
+      <div class="skillnew-error"
+           th:if="${#fields.hasErrors('learningTime')}"
+           th:errors="*{learningTime}"></div>
+  
+      <div class="skillnew-actions">
+        <button type="submit" class="skillnew-submit">追加する</button>
+      </div>
+    </div>
+  </form>
+</main>
+
+<!-- 完了モーダル -->
+<div class="modal fade" id="saveDoneModal" tabindex="-1" aria-hidden="true"
+     th:classappend="${saved} ? ' show' : ''" th:attr="style=${saved} ? 'display:block;' : 'display:none;'">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 class="modal-title fs-5">登録が完了しました</h2>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+      </div>
+      <div class="modal-body">
+        選択月（<span th:text="${month}">YYYY-MM</span>）として保存しました。
+      </div>
+      <div class="modal-footer">
+        <a class="btn btn-primary" th:href="@{/skill/edit(month=${month})}">編集ページに戻る</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 共通フッター -->
+<div th:replace="~{common/footer :: footer}"></div>
+
+<script th:inline="javascript">
+  document.addEventListener('DOMContentLoaded', function () {
+    /*[[${saved}]]*/ false && new bootstrap.Modal(document.getElementById('saveDoneModal')).show();
+  });
+</script>
+<script>
+  document.addEventListener('click', function(e){
+    if(!e.target.classList.contains('spin-btn')) return;
+    const wrap = e.target.closest('.skillnew-numwrap');
+    if(!wrap) return;
+    const input = wrap.querySelector('input[type="number"]');
+    if(!input) return;
+  
+    const step = Number(input.step) || 1;
+    const min  = (input.min !== "") ? Number(input.min) : -Infinity;
+    const val  = (input.value === "") ? 0 : Number(input.value);
+  
+    if(e.target.classList.contains('spin-up')){
+      input.value = val + step;
+    }else{
+      const next = val - step;
+      input.value = Math.max(next, min);
+    }
+    // 入力イベントを発火（バリデーション反映など）
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 項目追加機能実装


### 概要
項目の追加機能を実装しました。
「項目を追加する」から遷移したページで項目名・学習時間を入力し、プルダウンで選択中の月のデータとして登録できます。登録後は登録完了モーダルを表示し、**「編集ページに戻る」**で一覧へ遷移します。

---

### 実装内容

- /skill/new?month={YYYY-MM}&categoryId={id} へ遷移し、選択中の月として登録
- 正常登録時　
  - DBへ保存
  - 登録完了モーダル表示（文言：{カテゴリー名} に {項目名} を 改行 {学習時間}分で追加しました！）
  - 「編集ページに戻る」ボタンで /skill/edit?month={登録月} に遷移

---

### バリデーション

#### 項目名
- 空ではない
- 同じ月で重複していない
- 50文字以内

#### 学習時間
- 空ではない
- 0以上の数字である
- 上限なし

#### バリデーションメッセージ（各入力欄直下・赤字表示）
- 空 「〜〜〜は必ず入力してください」
- 重複 「〜〜〜（入力した項目名）は既に登録されています」
- 50文字以内 「項目名は50文字以内で入力してください」
- 0以上の数字 「学習時間は0以上の数字で入力してください」

---

### 動作確認内容

- 編集画面のプルダウンで月を選択 → 「項目を追加する」で /skill/new?month={選択月}&categoryId={id} に遷移すること
- 8月選択中に登録すると8月のデータとして保存されること
- バリデーションメッセージは各項目の入力フォームの下に赤字で表示すること
- 正しくDBに保存され、登録できたら、登録完了モーダルを表示すること
- モーダルの「編集ページに戻る」を押下すると項目一覧画面に遷移すること