### PR TITLE
Feat/skill time edit

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/LearningChartController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/LearningChartController.java
@@ -1,21 +1,28 @@
 package com.spring.springbootapplication.controller;
 
+import com.spring.springbootapplication.dao.LearningDataMapper;
+import com.spring.springbootapplication.entity.Category;
 import com.spring.springbootapplication.entity.LearningData;
 import com.spring.springbootapplication.entity.User;
-import com.spring.springbootapplication.entity.Category;              // ★ ここを自分のパッケージに合わせる
+import com.spring.springbootapplication.service.CategoryService;
 import com.spring.springbootapplication.service.LearningChartService;
 import com.spring.springbootapplication.service.UserService;
-import com.spring.springbootapplication.service.CategoryService;      // ★ 追加
+import com.spring.springbootapplication.dto.LearningTimeEditForm;
 
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
 import static java.util.stream.Collectors.groupingBy;
 
 @Controller
@@ -23,26 +30,25 @@ public class LearningChartController {
 
     private final UserService userService;
     private final LearningChartService learningChartService;
-    private final CategoryService categoryService;                   // ★ 追加
+    private final CategoryService categoryService;
+    private final LearningDataMapper learningDataMapper;  // ← 追加
 
-    // ★ コンストラクタは1つに統一（Springが自動DI）
+    // ★ コンストラクタは1本に統一
     public LearningChartController(UserService userService,
                                    LearningChartService learningChartService,
-                                   CategoryService categoryService) {
+                                   CategoryService categoryService,
+                                   LearningDataMapper learningDataMapper) {
         this.userService = userService;
         this.learningChartService = learningChartService;
         this.categoryService = categoryService;
+        this.learningDataMapper = learningDataMapper;
     }
 
-    /**
-     * 学習チャート表示ページ
-     * 初期表示 or 月変更後に使用
-     */
+    /** 学習チャート表示（編集画面） */
     @GetMapping("/skill/edit")
     public String showChartPage(@RequestParam(value = "month", required = false) String month,
                                 HttpSession session,
                                 Model model) {
-
         // ログインチェック
         User loginUser = userService.getCurrentUser(session);
         if (loginUser == null) return "redirect:/login";
@@ -63,13 +69,13 @@ public class LearningChartController {
         // カテゴリ一覧（id昇順）
         List<Category> categories = categoryService.findAllOrderById();
 
-        // category_id ごとにグルーピング（Map<categoryId, List<LearningData>>）
+        // category_id ごとにグルーピング
         Map<Integer, List<LearningData>> byCat =
             dataList.stream()
                     .filter(Objects::nonNull)
                     .collect(groupingBy(LearningData::getCategoryId));
 
-        // 月プルダウンデータ
+        // 月プルダウン
         List<String> availableMonths = learningChartService.getAvailableMonths();
         List<String> availableMonthsLabel = availableMonths.stream()
                 .map(m -> Integer.parseInt(m.substring(5, 7)) + "月")
@@ -78,7 +84,6 @@ public class LearningChartController {
         // Viewへ
         model.addAttribute("categories", categories);
         model.addAttribute("byCat", byCat);
-
         model.addAttribute("learningDataList", dataList);
         model.addAttribute("selectedMonth", month);
         model.addAttribute("selectedMonthLabel", selectedMonthLabel);
@@ -88,5 +93,43 @@ public class LearningChartController {
         model.addAttribute("isLoginPage", false);
 
         return "skill_edit";
+    }
+
+    /** 学習時間の保存（hiddenフォームからPOST） */
+    @PostMapping("/skill/time")
+    public String updateTime(@Valid LearningTimeEditForm form,
+                             BindingResult br,
+                             HttpSession session,
+                             RedirectAttributes ra) {
+
+        User current = userService.getCurrentUser(session);
+        if (current == null) return "redirect:/login";
+
+        // 入力エラー時は一覧へ戻る
+        if (br.hasErrors()) {
+            ra.addAttribute("month", form.getMonth());
+            return "redirect:/skill/edit";
+        }
+
+        // 所有者チェック
+        LearningData data = learningDataMapper.findByIdAndUserId(form.getId(), current.getId());
+        if (data == null) {
+            ra.addAttribute("month", form.getMonth());
+            return "redirect:/skill/edit";
+        }
+
+        // 更新
+        learningDataMapper.updateLearningTime(form.getId(), current.getId(), form.getLearningTime());
+
+        // モーダル用フラッシュ属性
+        ra.addFlashAttribute("saved", true);
+        ra.addFlashAttribute("savedItem", data.getItem());
+        ra.addFlashAttribute("savedTime", form.getLearningTime());
+        ra.addFlashAttribute("categoryName", categoryService.getNameById(data.getCategoryId()));
+        ra.addFlashAttribute("month", form.getMonth());
+
+        // 一覧へ戻る（GETで saved を拾ってモーダル表示）
+        ra.addAttribute("month", form.getMonth());
+        return "redirect:/skill/edit";
     }
 }

--- a/src/main/java/com/spring/springbootapplication/dao/LearningDataMapper.java
+++ b/src/main/java/com/spring/springbootapplication/dao/LearningDataMapper.java
@@ -9,29 +9,56 @@ import java.util.List;
 public interface LearningDataMapper {
 
     // 既存分：指定ユーザー・月のデータ取得
-    @Select("SELECT * FROM learning_data WHERE user_id = #{userId} AND learning_month = #{learningMonth}")
+    @Select("""
+        SELECT *
+          FROM learning_data
+         WHERE user_id = #{userId}
+           AND learning_month = #{learningMonth}
+      ORDER BY category_id ASC, id ASC   -- ★ 並びを固定
+    """)
     List<LearningData> findByUserIdAndMonth(@Param("userId") int userId,
                                             @Param("learningMonth") String learningMonth);
 
-    // 追加分：同一ユーザー・同一月・同一項目名の重複チェック
+    // 既存分：同一ユーザー×同一月×同一項目の重複チェック
     @Select("""
         SELECT COUNT(*)
           FROM learning_data
          WHERE user_id = #{userId}
            AND learning_month = #{month}
            AND item = #{item}
-        """)
+    """)
     int countByUserAndMonthAndItem(@Param("userId") int userId,
                                    @Param("month") String month,
                                    @Param("item") String item);
 
-    // 追加分：登録
+    // 既存分：登録
     @Insert("""
         INSERT INTO learning_data
           (user_id, category_id, item, learning_month, learning_time, created_at, updated_at)
         VALUES
-          (#{userId}, #{categoryId}, #{item}, #{learningMonth}, #{learningTime}, now(), now())
-        """)
+          (#{userId}, #{categoryId}, #{item}, #{learningMonth}, #{learningTime}, NOW(), NOW())
+    """)
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(LearningData data);
+
+    // 所有者チェック付きで1件取得（編集対象の存在確認）
+    @Select("""
+        SELECT *
+          FROM learning_data
+         WHERE id = #{id}
+           AND user_id = #{userId}
+    """)
+    LearningData findByIdAndUserId(@Param("id") int id, @Param("userId") int userId);
+
+    // 学習時間の更新（所有者縛り）
+    @Update("""
+        UPDATE learning_data
+           SET learning_time = #{learningTime},
+               updated_at = NOW()
+         WHERE id = #{id}
+           AND user_id = #{userId}
+    """)
+    int updateLearningTime(@Param("id") int id,
+                           @Param("userId") int userId,
+                           @Param("learningTime") int learningTime);
 }

--- a/src/main/java/com/spring/springbootapplication/dto/LearningTimeEditForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/LearningTimeEditForm.java
@@ -1,0 +1,19 @@
+package com.spring.springbootapplication.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class LearningTimeEditForm {
+    @NotNull private Integer id;
+    @NotNull @Min(value = 0, message = "学習時間は0以上の数字で入力してください")
+    private Integer learningTime;
+    @NotBlank private String month;
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+    public Integer getLearningTime() { return learningTime; }
+    public void setLearningTime(Integer learningTime) { this.learningTime = learningTime; }
+    public String getMonth() { return month; }
+    public void setMonth(String month) { this.month = month; }
+}

--- a/src/main/resources/templates/skill_edit.html
+++ b/src/main/resources/templates/skill_edit.html
@@ -133,17 +133,12 @@
             <div class="modal-body text-center">
               <p class="modal-success__msg">
                 <span class="msg-row">
-                  <span class="msg-strong" th:text="${categoryName}">カテゴリー名</span>
-                  の
                   <span class="msg-strong" th:text="${savedItem}">項目名</span>
-                  を
-                </span>
-                <span class="msg-row">
-                  <span class="msg-strong" th:text="${savedTime}">60</span>分に更新しました！
+                  の学習時間を保存しました！
                 </span>
               </p>
             </div>
-            <div class="modal-footer justify-content-center">
+             <div class="modal-footer justify-content-center">
               <a class="modal-success__btn" th:href="@{/skill/edit(month=${month})}">
                 編集ページに戻る
               </a>

--- a/src/main/resources/templates/skill_edit.html
+++ b/src/main/resources/templates/skill_edit.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
 <head>
   <meta charset="UTF-8" />
   <title>スキル編集</title>
@@ -34,7 +34,7 @@
             <span class="num"
                   th:text="${selectedMonthLabel != null ? #strings.substring(selectedMonthLabel, 0, #strings.length(selectedMonthLabel) - 1) : ''}">3</span>月
           </button>
-          
+
           <ul class="month-menu" role="listbox" aria-labelledby="monthToggle" hidden>
             <li th:each="m, iterStat : ${availableMonths}">
               <button type="button"
@@ -47,7 +47,7 @@
               </button>
             </li>
           </ul>
-      
+
           <!-- 実際に送る値 -->
           <input type="hidden" name="month" id="monthHidden" th:value="${selectedMonth}">
         </div>
@@ -60,79 +60,115 @@
                  th:each="c : ${categories}"
                  th:with="list=${byCat[c.id]}">
 
-    <div class="category-content">
+          <div class="category-content">
 
-      <!-- タイトル行：DBの category_name を見出しに -->
-      <div class="category-row title-row">
-        <div class="category-title-box">
-          <span class="category-title-text" th:text="${c.categoryName}">カテゴリ</span>
-        </div>
-        <th:block th:with="m=${selectedMonth != null ? selectedMonth : (param.month != null ? param.month[0] : null)}">
-          <a class="add-item-btn"
-             th:href="@{/skill/new(month=${m}, categoryId=${c.id})}">
-            項目を追加する
-          </a>
-        </th:block>
-      </div>
-
-      <div class="items-panel">
-        <div class="items-controls">
-          <div class="control-box">項目名</div>
-          <div class="control-box">学習時間</div>
-        </div>
-
-        <!-- list が null/空でも枠は出し、行は描画されないだけ -->
-        <div class="items-list">
-          <div class="item-row" th:each="d : ${list}">
-            <!-- 項目名 -->
-            <div class="cell name-cell">
-              <span class="item-text" th:text="${d.item}">-</span>
-            </div>
-
-            <!-- 学習時間 -->
-            <div class="cell time-cell">
-              <div class="learning-time-box">
-                <span class="learning-time-text"
-                      th:text="${d.learningTime} ?: (${d['learning_time']} ?: 0)">0</span>
-                <div class="learning-time-dropdown">
-                  <button type="button" class="time-up" aria-label="増やす"><div class="triangle-up"></div></button>
-                  <button type="button" class="time-down" aria-label="減らす"><div class="triangle-down"></div></button>
-                </div>
+            <!-- タイトル行：DBの category_name を見出しに -->
+            <div class="category-row title-row">
+              <div class="category-title-box">
+                <span class="category-title-text" th:text="${c.categoryName}">カテゴリ</span>
               </div>
+              <th:block th:with="m=${selectedMonth != null ? selectedMonth : (param.month != null ? param.month[0] : null)}">
+                <a class="add-item-btn"
+                   th:href="@{/skill/new(month=${m}, categoryId=${c.id})}">
+                  項目を追加する
+                </a>
+              </th:block>
             </div>
 
-            <!-- 保存 / 削除 -->
-            <div class="cell save-cell">
-              <button class="btn-save" type="button">学習時間を保存する</button>
-            </div>
-            <div class="cell delete-cell">
-              <button class="btn-delete" type="button">削除する</button>
-            </div>
-          </div><!-- /.item-row -->
-        </div><!-- /.items-list -->
-      </div><!-- /.items-panel -->
+            <div class="items-panel">
+              <div class="items-controls">
+                <div class="control-box">項目名</div>
+                <div class="control-box">学習時間</div>
+              </div>
 
-    </div><!-- /.category-content -->
-  </section><!-- /.category-box -->
-</section><!-- /.categories-grid -->
-      
+              <!-- list が null/空でも枠は出し、行は描画されないだけ -->
+              <div class="items-list">
+                <div class="item-row" th:each="d : ${list}" th:attr="data-id=${d.id}">
+                  <!-- 項目名 -->
+                  <div class="cell name-cell">
+                    <span class="item-text" th:text="${d.item}">-</span>
+                  </div>
+
+                  <!-- 学習時間 -->
+                  <div class="cell time-cell">
+                    <div class="learning-time-box">
+                      <span class="learning-time-text"
+                            th:text="${d.learningTime} ?: (${d['learning_time']} ?: 0)">0</span>
+                      <div class="learning-time-dropdown">
+                        <button type="button" class="time-up" aria-label="増やす"><div class="triangle-up"></div></button>
+                        <button type="button" class="time-down" aria-label="減らす"><div class="triangle-down"></div></button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- 保存 / 削除 -->
+                  <div class="cell save-cell">
+                    <button class="btn-save" type="button">学習時間を保存する</button>
+                  </div>
+                  <div class="cell delete-cell">
+                    <button class="btn-delete" type="button">削除する</button>
+                  </div>
+                </div><!-- /.item-row -->
+              </div><!-- /.items-list -->
+            </div><!-- /.items-panel -->
+
+          </div><!-- /.category-content -->
+        </section><!-- /.category-box -->
+      </section><!-- /.categories-grid -->
+
+      <!-- 送信用の hidden フォーム（見た目影響なし） -->
+      <form id="timeUpdateForm" th:action="@{/skill/time}" method="post" hidden>
+        <input type="hidden" name="id" id="timeUpdateId" />
+        <input type="hidden" name="learningTime" id="timeUpdateValue" />
+        <input type="hidden" name="month" id="timeUpdateMonth" th:value="${selectedMonth}" />
+        <!-- Security 使用時のみ（あるなら） -->
+        <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+      </form>
+
+      <!-- 保存完了モーダル（/skill/new と同系統） -->
+      <div class="modal fade modal-success" id="editDoneModal" tabindex="-1" aria-hidden="true"
+           data-bs-backdrop="static" data-bs-keyboard="false">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-body text-center">
+              <p class="modal-success__msg">
+                <span class="msg-row">
+                  <span class="msg-strong" th:text="${categoryName}">カテゴリー名</span>
+                  の
+                  <span class="msg-strong" th:text="${savedItem}">項目名</span>
+                  を
+                </span>
+                <span class="msg-row">
+                  <span class="msg-strong" th:text="${savedTime}">60</span>分に更新しました！
+                </span>
+              </p>
+            </div>
+            <div class="modal-footer justify-content-center">
+              <a class="modal-success__btn" th:href="@{/skill/edit(month=${month})}">
+                編集ページに戻る
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
 
     </main>
 
     <!-- フッター -->
     <footer th:replace="common/footer :: footer"></footer>
-
   </div>
 
+  <!-- 月プルダウン & 保存送信（IIFEでまとめてバグ防止） -->
   <script>
-    (() => {
-      const dd = document.querySelector('.month-dd');
-      if (!dd) return;
+  (() => {
+    const dd     = document.querySelector('.month-dd');
+    if (dd) {
       const toggle = dd.querySelector('.month-toggle');
-      const menu = dd.querySelector('.month-menu');
+      const menu   = dd.querySelector('.month-menu');
       const hidden = document.getElementById('monthHidden');
-      const form = document.getElementById('monthForm');
-    
+      const form   = document.getElementById('monthForm');
+
+      // 開閉
       toggle.addEventListener('click', () => {
         const open = toggle.getAttribute('aria-expanded') === 'true';
         toggle.setAttribute('aria-expanded', String(!open));
@@ -142,7 +178,8 @@
           first && first.focus();
         }
       });
-    
+
+      // 選択
       menu.addEventListener('click', (e) => {
         const btn = e.target.closest('.month-item');
         if (!btn) return;
@@ -153,14 +190,8 @@
         toggle.setAttribute('aria-expanded','false');
         form.submit();
       });
-    
-      document.addEventListener('click', (e) => {
-        if (!dd.contains(e.target)) {
-          menu.hidden = true;
-          toggle.setAttribute('aria-expanded','false');
-        }
-      });
-    
+
+      // キーボード
       dd.addEventListener('keydown', (e) => {
         const items = Array.from(menu.querySelectorAll('.month-item'));
         const idx = items.indexOf(document.activeElement);
@@ -178,28 +209,63 @@
           document.activeElement.click();
         }
       });
-    })();
+    }
+
+    // 「学習時間を保存する」→ hidden フォーム送信
+    document.addEventListener('click', function(e){
+      const saveBtn = e.target.closest('.btn-save');
+      if (!saveBtn) return;
+
+      const row = saveBtn.closest('.item-row');
+      if (!row) return;
+
+      const id    = row.dataset.id;
+      const label = row.querySelector('.learning-time-text');
+      const month = document.getElementById('monthHidden')?.value || '';
+
+      let val = parseInt(label?.textContent || '0', 10);
+      if (Number.isNaN(val)) val = 0;
+
+      const postForm = document.getElementById('timeUpdateForm');
+      document.getElementById('timeUpdateId').value    = id;
+      document.getElementById('timeUpdateValue').value = String(val);
+      document.getElementById('timeUpdateMonth').value = month;
+
+      postForm.submit();
+    });
+  })();
   </script>
+
+  <!-- 保存完了フラグでモーダル起動（フラッシュ属性から） -->
+  <script th:inline="javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+      const saved = /*[[${saved}]]*/ false;
+      if (saved) {
+        const m = new bootstrap.Modal(document.getElementById('editDoneModal'));
+        m.show();
+      }
+    });
+  </script>
+
+  <!-- 三角で学習時間の増減（見た目は既存のまま） -->
   <script>
     document.addEventListener('click', function (e) {
-      // 三角（またはその内側）をクリックしたか？
       const isUp = e.target.closest('.triangle-up');
       const isDown = e.target.closest('.triangle-down');
       if (!isUp && !isDown) return;
-  
-      // 対象行のボックスと表示ラベルを取得
+
       const box = e.target.closest('.learning-time-box');
       if (!box) return;
-  
+
       const label = box.querySelector('.learning-time-text');
       if (!label) return;
-  
+
       let val = parseInt(label.textContent || '0', 10);
       if (Number.isNaN(val)) val = 0;
-  
+
       if (isUp)   val += 1;
       if (isDown) val = Math.max(0, val - 1); // 0未満にしない
-  
+
       label.textContent = val;
     });
   </script>


### PR DESCRIPTION
## 項目編集機能実装


### 概要
学習時間の編集機能を実装しました。
学習時間を変更し、「学習時間を保存する」ボタンを押下すると学習時間の編集ができます。編集後は編集完了モーダルを表示し、**「編集ページに戻る」**で項目一覧画面へ遷移します。

---

### 実装内容

- 各行に data-id を付与（見た目変更なし・HTML側に載せる“任意のメモ” で、データベースのカラムではない）。
- 送信用の hiddenフォーム を1つ追加し、行の「学習時間を保存する」クリックで id / learningTime / month をPOST
  - DBを更新
  - 成功時モーダルを追加（文言：「{項目名} の学習時間を保存しました！」）

---

### 動作確認内容

- 編集画面のプルダウンで月を選択 → 三角UIで学習時間を増減 → 「学習時間を保存する」ボタンを押下すると学習時間の編集ができること
- 8月選択中に登録すると8月のデータとして保存されること
- 三角UIで学習時間を増減は0以下にはならないこと
- 正しくDBが更新され、登録できたら、編集完了モーダルを表示すること
- モーダルの「編集ページに戻る」を押下すると項目一覧画面に遷移すること