### PR TITLE
Feat/skill time edit

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/LearningChartController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/LearningChartController.java
@@ -86,6 +86,7 @@ public class LearningChartController {
         model.addAttribute("byCat", byCat);
         model.addAttribute("learningDataList", dataList);
         model.addAttribute("selectedMonth", month);
+        model.addAttribute("month", month); 
         model.addAttribute("selectedMonthLabel", selectedMonthLabel);
         model.addAttribute("selectedMonthNumber", selectedMonthNumber);
         model.addAttribute("availableMonths", availableMonths);

--- a/src/main/java/com/spring/springbootapplication/controller/SkillItemController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillItemController.java
@@ -41,6 +41,7 @@ public class SkillItemController {
         form.setLearningMonth(month);
         form.setCategoryId(categoryId); 
         model.addAttribute("selectedMonth", month);
+        model.addAttribute("month", month);
         model.addAttribute("isLoginPage", false);
         model.addAttribute("categoryName", categoryService.getNameById(categoryId));
         return "skill_new";
@@ -77,6 +78,7 @@ public class SkillItemController {
             model.addAttribute("isLoginPage", false);
             // ★ エラーで戻すときも再セット（これを忘れると null になります）
             model.addAttribute("categoryName", categoryService.getNameById(form.getCategoryId()));
+            model.addAttribute("month", form.getLearningMonth());
             return "skill_new";
         }
 


### PR DESCRIPTION
## 項目編集機能実装


### 概要
学習時間の編集機能を実装しました。
学習時間を変更し、「学習時間を保存する」ボタンを押下すると学習時間の編集ができます。編集後は編集完了モーダルを表示し、**「編集ページに戻る」**で項目一覧画面へ遷移します。

---

### 実装内容

- 各行に data-id を付与（見た目変更なし・HTML側に載せる“任意のメモ” で、データベースのカラムではない）。
- 送信用の hiddenフォーム を1つ追加し、行の「学習時間を保存する」クリックで id / learningTime / month をPOST
- 正常登録時
  - DBを更新
  - 成功時モーダルを追加（文言：「{項目名} の学習時間を保存しました！」）

---

### 動作確認内容

- 編集画面のプルダウンで月を選択 → 三角UIで学習時間を増減 → 「学習時間を保存する」ボタンを押下すると学習時間の編集ができること
- 9月選択中に登録すると9月のデータとして保存されること
- 三角UIで学習時間を増減は0以下にはならないこと
- 正しくDBが更新され、登録できたら、編集完了モーダルを表示すること
- モーダルの「編集ページに戻る」を押下すると項目一覧画面に遷移すること