### PR TITLE
fix/register-error-message-typo

### DIFF
--- a/src/main/java/com/spring/springbootapplication/dto/UserForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/UserForm.java
@@ -14,7 +14,7 @@ public class UserForm {
     @Size(max = 255, message = "メールアドレスは255文字以内で入力してください")
     @Pattern(
         regexp = "^[^@\\s]+@[^@\\s]+[^@\\s]+$",
-        message = "メールアドレスの形式が正しくありません"
+        message = "メールアドレスが正しい形式ではありません"
 )
     private String email;
 


### PR DESCRIPTION
## 新規登録ページのエラーメッセージ表記修正


### 概要
【テスト仕様書】NG項目の修正1_エラーメッセージの表記間違いを修正しました

---

### 修正内容

- メールアドレス形式ではない入力があった場合のエラーメッセージが「メールアドレスの形式が正しくありません」と表示され、要件と合っていない部分を「メールアドレスが正しい形式ではありません」と表示されるように修正

---

### 動作確認内容

- エラーメッセージとして「メールアドレスが正しい形式ではありません」と表示されること